### PR TITLE
Rename `check` script to `biome`

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@vercel/ncc": "0.38.4"
   },
   "scripts": {
-    "build": "ncc build src/index.js",
-    "check": "biome check --write ."
+    "biome": "biome check --write .",
+    "build": "ncc build src/index.js"
   }
 }


### PR DESCRIPTION
Yarn already has a `yarn check` command, so you couldn't run `yarn check` to run Biome. With this you can instead run `yarn biome`.